### PR TITLE
Add test script, upgrade to Java 8 and update Tomcat

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM tifayuki/java:7
+FROM tifayuki/java:8
 MAINTAINER Feng Honglin <hfeng@tutum.co>
 
 RUN apt-get update && \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM tifayuki/java:7
+FROM tifayuki/java:8
 MAINTAINER Feng Honglin <hfeng@tutum.co>
 
 RUN apt-get update && \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM tifayuki/java:7
+FROM tifayuki/java:8
 MAINTAINER Feng Honglin <hfeng@tutum.co>
 
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TOMCAT_MAJOR_VERSION 6
-ENV TOMCAT_MINOR_VERSION 6.0.41
+ENV TOMCAT_MINOR_VERSION 6.0.44
 ENV CATALINA_HOME /tomcat
 
 # INSTALL TOMCAT

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM tifayuki/java:7
+FROM tifayuki/java:8
 MAINTAINER Feng Honglin <hfeng@tutum.co>
 
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TOMCAT_MAJOR_VERSION 7
-ENV TOMCAT_MINOR_VERSION 7.0.55
+ENV TOMCAT_MINOR_VERSION 7.0.64
 ENV CATALINA_HOME /tomcat
 
 # INSTALL TOMCAT

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM tifayuki/java:7
+FROM tifayuki/java:8
 MAINTAINER Feng Honglin <hfeng@tutum.co>
 
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TOMCAT_MAJOR_VERSION 8
-ENV TOMCAT_MINOR_VERSION 8.0.11
+ENV TOMCAT_MINOR_VERSION 8.0.28
 ENV CATALINA_HOME /tomcat
 
 # INSTALL TOMCAT

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+tomcat_test()
+{
+    local version="$1"
+
+    echo -e "\e[1m=> Building tomcat-${version} image...\e[0m"
+    docker build -t tomcat-${version} ${version}
+
+    echo -e "\e[1m=> Running tomcat-${version} container...\e[0m"
+    local cid=$(docker run -d tomcat-${version})
+    local cip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${cid})
+
+    echo -e "\e[1m=> Testing tomcat-${version} serves Tomcat default page on http://${cip}:8080/...\e[0m"
+    sleep 10
+    wget --spider http://${cip}:8080/
+}
+
+tomcat_test 4.1
+tomcat_test 5.5
+tomcat_test 6.0
+tomcat_test 7.0
+tomcat_test 8.0
+echo -e "\e[1m=> Done.\e[0m"


### PR DESCRIPTION
- Add simple test script to check Tomcat container serves default page.
- Upgrade Java version to Java 8.
- Update Tomcat version:
  - Tomcat 6 to 6.0.44
  - Tomcat 7 to 7.0.64
  - Tomcat 8 to 8.0.28
